### PR TITLE
update version in pxt.json to 3.0.2

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "educationcontent",
-    "version": "3.0.0",
+    "version": "3.0.2",
     "dependencies": {
         "core": "*",
         "builder": "*"

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "educationcontent",
-    "version": "1.1.3",
+    "version": "3.0.0",
     "dependencies": {
         "core": "*",
         "builder": "*"


### PR DESCRIPTION
Update the version in pxt.json to match the latest release; there's no exact issue right now, but we should make sure the version in pxt.json matches the current release. This should just make sure that we don't have the same version ordering issue again in the future (no need to change release or anything).

@MariaOlekheyko 