### PR TITLE
Move agent.inspect into conditional for lesson 8 activity 2

### DIFF
--- a/python/lesson8/activity2.md
+++ b/python/lesson8/activity2.md
@@ -7,15 +7,12 @@ agent.destroy(FORWARD)
 agent.place(RIGHT)
 agent.collect_all()
 agent.move(FORWARD, 5)
-agent.inspect(AgentInspection.BLOCK, FORWARD) 
 agent.till(BACK)
 for i in range(4):
       pass
-if True: 
+if agent.inspect(AgentInspection.BLOCK, FORWARD) == GRASS:
     pass
 else: 
-    pass
-elif:
     pass
 ```
 


### PR DESCRIPTION
- Remove extra elif 
- Move `agent.inspect` into if statement. The `agent.inspect` block returns a value, so if it is used in it's own line (instead of assigned to a variable or as an argument), it won't convert properly into blocks, which breaks the toolbox.

Fixes https://github.com/microsoft/pxt-minecraft/issues/1922